### PR TITLE
Binary search - initial bounds calculated may touch solution

### DIFF
--- a/src/main/java/com/rb/nonbiz/search/LowerAndUpperBoundsFinder.java
+++ b/src/main/java/com/rb/nonbiz/search/LowerAndUpperBoundsFinder.java
@@ -95,9 +95,9 @@ public class LowerAndUpperBoundsFinder {
     X upperBoundX = startingPointForSearchUpper;
 
     // possibly reduce the lower bound
-    if (comparisonLower >= 0) {
-      // The initial lower X-bound does not have a Y-value below the targetY.
-      // Keep reducing lowerBoundX until we get a Y below targetY, i.e. it becomes a real lower bound.
+    if (comparisonLower > 0) {
+      // The initial lower X-bound has a Y-value above the targetY.
+      // Keep reducing lowerBoundX until we get a Y below or at targetY, i.e. it becomes a real lower bound.
       int iIteration = 0;
       while (iIteration < maxIterations) {
         lowerBoundX = reduceLowerBound.apply(lowerBoundX);
@@ -108,7 +108,7 @@ public class LowerAndUpperBoundsFinder {
             lowerBoundYPrev.compareTo(lowerBoundY) >= 0,
             "new lowerBoundY %s must not be greater than previous lowerBoundY %s",
             lowerBoundY, lowerBoundYPrev);
-        if (lowerBoundY.compareTo(targetY) < 0) {
+        if (lowerBoundY.compareTo(targetY) <= 0) {
           break;
         }
         iIteration++;
@@ -122,7 +122,7 @@ public class LowerAndUpperBoundsFinder {
     }
 
     // possibly increase the upper bound
-    if (comparisonUpper <= 0) {
+    if (comparisonUpper < 0) {
       // The initial upper X-bound does not have a Y-value above the targetY.
       // Keep increasing upperBoundY until we get a Y above targetY, i.e. it becomes a real upper bound.
       int iIteration = 0;
@@ -135,7 +135,7 @@ public class LowerAndUpperBoundsFinder {
             yUpperBoundPrev.compareTo(upperBoundY) <= 0,
             "new upperBoundY %s must not be less than previous upperBoundY %s",
             upperBoundY, yUpperBoundPrev);
-        if (upperBoundY.compareTo(targetY) > 0) {
+        if (upperBoundY.compareTo(targetY) >= 0) {
           break;
         }
         iIteration++;

--- a/src/main/java/com/rb/nonbiz/search/LowerAndUpperBoundsFinder.java
+++ b/src/main/java/com/rb/nonbiz/search/LowerAndUpperBoundsFinder.java
@@ -123,8 +123,8 @@ public class LowerAndUpperBoundsFinder {
 
     // possibly increase the upper bound
     if (comparisonUpper < 0) {
-      // The initial upper X-bound does not have a Y-value above the targetY.
-      // Keep increasing upperBoundY until we get a Y above targetY, i.e. it becomes a real upper bound.
+      // The initial upper X-bound has a Y-value below the targetY.
+      // Keep increasing upperBoundY until we get a Y above (or at) targetY, i.e. it becomes a real upper bound.
       int iIteration = 0;
       while (iIteration < maxIterations) {
         upperBoundX = increaseUpperBound.apply(upperBoundX);

--- a/src/test/java/com/rb/nonbiz/search/LowerAndUpperBoundsFinderTest.java
+++ b/src/test/java/com/rb/nonbiz/search/LowerAndUpperBoundsFinderTest.java
@@ -74,8 +74,8 @@ public class LowerAndUpperBoundsFinderTest extends RBCommonsIntegrationTest<Lowe
         MAX_ITERATIONS);
     double valueAtLower = EVALUATE_INPUT_TO_SQUARE.apply(lowerAndUpperBounds.lowerEndpoint());
     double valueAtUpper = EVALUATE_INPUT_TO_SQUARE.apply(lowerAndUpperBounds.upperEndpoint());
-    assertTrue(valueAtLower < target);
-    assertTrue(valueAtUpper > target);
+    assertTrue(valueAtLower <= target);
+    assertTrue(valueAtUpper >= target);
   }
 
   // for the case of a starting range of guesses [lowerBound, upperBound]
@@ -186,7 +186,7 @@ public class LowerAndUpperBoundsFinderTest extends RBCommonsIntegrationTest<Lowe
   }
 
   @Test
-  public void cornerCase_cannotGoLower_butStartingOnTarget_returnsValue() {
+  public void cornerCase_exactlyOnTarget_returnsValue() {
     int maxIterations = 10;
     
     // The lower bound is already on target, but the upper bound isn't.


### PR DESCRIPTION
Our generic binary search code has an initial step where it calculates the initial bounds for the binary search. In certain cases, one (or both) of those bounds may be EXACTLY at the target (i.e. if it's a lower bound, it may not be lowered further, and if it's an upper bound, it may not be increased further). Our previous code was too conservative and it was looking for bounds such that lower < target < upper. Now this is changed so that lower <= target <= upper.